### PR TITLE
Add JoinColumn to shopProduct field so that column names are consistent

### DIFF
--- a/src/main/java/com/revature/models/CartItem.java
+++ b/src/main/java/com/revature/models/CartItem.java
@@ -34,6 +34,7 @@ public class CartItem {
 
 
     @OneToOne
+    @JoinColumn(name = "shop_product_id")
     private ShopProduct shopProduct;
 
     public CartItem(int quantity, boolean saved, User customer, ShopProduct shopProduct) {


### PR DESCRIPTION
Fixes the column name shopProduct in CartItem (in database it was showing up as shop_product_shop_product_id)